### PR TITLE
add filter to search query

### DIFF
--- a/lib/queries/search.js
+++ b/lib/queries/search.js
@@ -32,4 +32,4 @@ util.inherits(SearchQuery, Query)
 
 Query.type(SearchQuery, 'search')
 Query.required(SearchQuery, 'granularity', 'intervals', 'query', 'sort')
-Query.addFields(SearchQuery, ['granularity', 'searchDimensions', 'query', 'sort', 'interval', 'intervals'])
+Query.addFields(SearchQuery, ['granularity', 'searchDimensions', 'query', 'sort', 'interval', 'intervals', 'filter'])


### PR DESCRIPTION
filter is an optional but supported field for search queries.  See http://druid.io/docs/latest/SearchQuery.html