### PR TITLE
Update+modularize Lodash & conform to semver

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var DruidError = require('./errors').DruidError
-  , lodash = require('lodash')
+  , each = require('lodash.foreach')
   , request = require('request')
   , util = require('util')
   , utils = require('./utils')
@@ -15,7 +15,7 @@ module.exports = Client
 
 
 // Expose all queries types
-lodash.each(queries, function(queryClass, type) {
+each(queries, function(queryClass, type) {
   Client.prototype[type] = function(rawQuery) {
     return new queryClass(this, rawQuery)
   }

--- a/lib/druid.js
+++ b/lib/druid.js
@@ -4,7 +4,8 @@ var Client = require('./client')
   , debug = require('debug')('druid-query:druid')
   , DruidError = require('./errors').DruidError
   , EventEmitter = require('events').EventEmitter
-  , lodash = require('lodash')
+  , each = require('lodash.foreach')
+  , values = require('lodash.values')
   , request = require('request')
   , util = require('util')
   , utils = require('./utils')
@@ -374,7 +375,7 @@ util.inherits(Druid, EventEmitter)
 
 
 // Expose all queries types
-lodash.each(queries, function(queryClass, type) {
+each(queries, function(queryClass, type) {
   Druid.prototype[type] = function(dataSource, rawQuery) {
     if (!dataSource) {
       throw new DruidError('Data source is not specified')
@@ -420,7 +421,7 @@ Druid.prototype.getDataSources = function() {
  * @returns {DruidNode[]}
  */
 Druid.prototype.getNodes = function() {
-  return lodash.values(this.nodes)
+  return values(this.nodes)
 }
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var Druid = require('./druid')
-  , lodash = require('lodash')
+  , each = require('lodash.foreach')
   , utils = require('./utils')
   , queries = utils.moduleMap(__dirname + '/queries')
 
@@ -16,6 +16,6 @@ Druid.Client = require('./client')
 Druid.Query = require('./query')
 
 // And all typed queries
-lodash.each(queries, function(queryClass) {
+each(queries, function(queryClass) {
   Druid[queryClass.name] = queryClass
 })

--- a/lib/query.js
+++ b/lib/query.js
@@ -1,7 +1,8 @@
 'use strict'
 
 var errors = require('./errors')
-  , lodash = require('lodash')
+  , assign = require('lodash.assign')
+  , each = require('lodash.foreach')
   , utils = require('./utils')
   , FieldError = errors.FieldError
   , MissingFieldError = errors.MissingFieldError
@@ -78,7 +79,7 @@ function Query(client, rawQuery) {
     // we do not want to change query type, aren't we?
     this._queryType && delete rawQuery.queryType
 
-    lodash.assign(this._query, rawQuery)
+    assign(this._query, rawQuery)
   }
 }
 
@@ -99,7 +100,7 @@ Query.addFields = function(queryClass, fieldList) {
   loadFields(fieldList, addMethods)
 
   function addMethods(methods) {
-    lodash.each(methods, eachMethod)
+    each(methods, eachMethod)
 
     function eachMethod(fn, name) {
       if (typeof fn === 'string') {
@@ -156,7 +157,7 @@ Query.addStatic = function(queryClass, fieldList) {
   loadFields(fieldList, addMethods)
 
   function addMethods(methods) {
-    lodash.each(methods, eachMethod)
+    each(methods, eachMethod)
   }
 
   function eachMethod(fn, name) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "query",
     "http"
   ],
-  "version": "0.0.13",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "repository": {
     "type": "git",
@@ -18,7 +18,9 @@
   "dependencies": {
     "custom-error-generator": "^7.0.0",
     "debug": "^2.1.0",
-    "lodash": "^2.4.1",
+    "lodash.assign": "^4.0.2",
+    "lodash.foreach": "^4.0.0",
+    "lodash.values": "^4.0.0",
     "node-zookeeper-client": "^0.2.1",
     "request": "^2.49.0"
   },
@@ -27,8 +29,11 @@
     "mocha": "^2.0.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive -R spec spec/"
+    "test": "mocha --recursive -R spec spec/"
   },
   "author": "Alexander Makarenko <estliberitas@gmail.com>",
+  "contributors": [
+    "James Womack <jwomack@netflix.com>"
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
* Use Lodash modules instead of full lodash, increasing performance of
  installing and running the code
* Conforming to semantic versioning to work better with tools as well
  as how developer think about Node modules today

The version will need to be changed to 1.0.0 and then the package will need to be published to NPM.
This can be done by running `npm version major && npm publish` after merge.

I can do this also if added to the collaborators of the project in NPM's system.