### PR TITLE
Selector filter should accept null or empty string

### DIFF
--- a/lib/fields/filters/selector.js
+++ b/lib/fields/filters/selector.js
@@ -12,7 +12,12 @@ var FieldError = require('../../errors').FieldError
  * @param {*} value Value to match
  */
 module.exports = function(dimension, value) {
-  if (!dimension || !value) {
+  if (!dimension || typeof value === 'undefined') {
+    // convert to empty string, null/empty string are the same thing to druid
+    if (value === null) {
+      value = ''
+    }
+
     throw new FieldError('Dimension or value is not specified')
   }
 

--- a/lib/fields/filters/selector.js
+++ b/lib/fields/filters/selector.js
@@ -13,12 +13,12 @@ var FieldError = require('../../errors').FieldError
  */
 module.exports = function(dimension, value) {
   if (!dimension || typeof value === 'undefined') {
-    // convert to empty string, null/empty string are the same thing to druid
-    if (value === null) {
-      value = ''
-    }
-
     throw new FieldError('Dimension or value is not specified')
+  }
+
+  // convert to empty string, null/empty string are the same thing to druid
+  if (value === null) {
+    value = ''
   }
 
   this.dimension = dimension


### PR DESCRIPTION
It should be valid to filter on null/empty values in Druid. This loosens the validation for the value argument and converts a null type to an empty string for Druid to parse as null/empty.