### PR TITLE
Removed required field intervals from SegmentMetadataQuery.

### DIFF
--- a/lib/queries/segmentMetadata.js
+++ b/lib/queries/segmentMetadata.js
@@ -31,5 +31,4 @@ util.inherits(SegmentMetadataQuery, Query)
 
 
 Query.type(SegmentMetadataQuery, 'segmentMetadata')
-Query.required(SegmentMetadataQuery, 'intervals')
 Query.addFields(SegmentMetadataQuery, ['interval', 'intervals', 'toInclude', 'merge'])


### PR DESCRIPTION
As specified in the druid documentation "SegmentMetadata" queries are working fine without specifying any intervals. Tested it and it works.