### PR TITLE
Allow empty orderBy array.

### DIFF
--- a/lib/fields/limitSpec.js
+++ b/lib/fields/limitSpec.js
@@ -34,7 +34,7 @@ function limitSpec(type, limit, orderByColumns) {
   else if (isNaN(limit)) {
     throw new FieldTypeError('limitSpec.limit', 'number')
   }
-  else if (!Array.isArray(orderByColumns) || !orderByColumns.length) {
+  else if (!Array.isArray(orderByColumns)) {
     throw new FieldTypeError('limitSpec.columns', 'array')
   }
 


### PR DESCRIPTION
In the current version one can not specify a limit without giving an ordering, too. 

But Druid [knows](https://github.com/druid-io/druid/blob/master/processing/src/main/java/io/druid/query/groupby/orderby/DefaultLimitSpec.java#L86-L88) how to handle this case. Therefore I removed the array length check.