### PR TITLE
Adding support for query type contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ API
     * [.orderBy(dimension, [direction])](#static-object-orderbydimension-direction)
     * [.postAggregation(type, name, [args...])](#static-object-postaggregationtype-name-args)
     * [.postAggregations(list...)](#static-object-postaggregationslist)
-    * [.query(type, value...)](#static-object-querytype-value)
+    * [.query(type, value, caseSensitive)](#static-object-querytype-value)
     * [#aggregation(type, name, [args...])](#query-aggregationtype-name-args)
     * [#aggregations(list...)](#query-aggregationslist)
     * [#bound(value)](#query-boundvalue)
@@ -858,14 +858,15 @@ __Arguments__
 
 ---
 
-#### `Query` query([type], value...)
+#### `Query` query([type], value, caseSensitive)
 
 Set SearchQuery spec (`query` field).
 
 __Arguments__
 
-* type `string | object` - SearchQuery type: `insensitive_contains`, `fragment`. Or it can be `SearchQuerySpec` object.
-* value `string | string[] | ...string` - Value(s) to match. If `type` is `fragment` value is treated as array. If type is `insensitive_contains` value is used as `string`.
+* type `string | object` - SearchQuery type: `insensitive_contains`, `fragment`, `contains`. Or it can be `SearchQuerySpec` object.
+* value `string | string[]` - Value(s) to match. If `type` is `fragment` value is treated as array. If type is `insensitive_contains` value is used as `string`.
+* caseSensitive `boolean` -  Whether strings should be compared as case sensitive or not. Has no effect for type `insensitive_contains`.
 
 ---
 

--- a/lib/fields/query.js
+++ b/lib/fields/query.js
@@ -13,10 +13,11 @@ module.exports = query
  *
  * @see http://druid.io/docs/0.6.121/SearchQuerySpec.html
  * @param {string|object} type Query spec type
- * @param {string|string[]|...string} value Value or array of fragments
+ * @param {string|string[]} value Value or array of fragments
+ * @param {boolean} caseSensitive Whether strings should be compared as case sensitive or not
  * @returns {object}
  */
-function query(type, value) {
+function query(type, value, caseSensitive) {
   if (utils.isObject(type)) {
     return type
   }
@@ -34,12 +35,20 @@ function query(type, value) {
   // FragmentSearchQuerySpec
   else if (type === 'fragment') {
     if (!Array.isArray(value)) {
-      value = utils.args(arguments, 1)
+      throw new FieldError('value is not an array')
     }
 
     return {
       type:   'fragment',
-      values: value
+      values: value,
+      caseSensitive: caseSensitive || false
+    }
+  }
+  else if (type === 'contains') {
+    return {
+      type:  'contains',
+      value: value + '',
+      caseSensitive: caseSensitive || false
     }
   }
   else {

--- a/spec/fields/searchQuery.js
+++ b/spec/fields/searchQuery.js
@@ -37,16 +37,8 @@ describe('Query', function() {
 
       expect(raw.query).to.eql({
         type:   'fragment',
-        values: ['fragment1', 'fragment2']
-      })
-    })
-
-    it('should set FragmentSearchQuerySpec using each argument as value', function() {
-      var raw = query.query('fragment', 'fragment1', 'fragment2').toJSON()
-
-      expect(raw.query).to.eql({
-        type:   'fragment',
-        values: ['fragment1', 'fragment2']
+        values: ['fragment1', 'fragment2'],
+        caseSensitive: false
       })
     })
 


### PR DESCRIPTION
Added query type `contains` and filter type `search`.

Unfortunately had to drop support of parsing query arguments to array. Since I introduced the `caseSensitive` parameter. But I would also be happy if you come up with a cooler solution. 

Thanks!!