### PR TITLE
Use string instead of json placeholder.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -159,7 +159,8 @@ Client.prototype.cancel = function(query, callback) {
       callback(new DruidError('No active query with ID "%s"', ctx.queryId))
     }
     else if (response.statusCode !== 200) {
-      callback(new DruidError('Unknown error (status: %d) while cancelling query: %j', response.statusCode, data))
+      callback(new DruidError('Unknown error (status: %d) while cancelling query: %s',
+       response.statusCode, JSON.stringify(data)))
     }
     else {
       callback(null)
@@ -222,7 +223,8 @@ Client.prototype.exec = function(query, callback) {
       callback(err)
     }
     else if (response.statusCode !== 200) {
-      callback(new DruidError('Unknown error (status: %d) while executing query: %j', response.statusCode, data))
+      callback(new DruidError('Unknown error (status: %d) while executing query: %s',
+       response.statusCode, JSON.stringify(data)))
     }
     else {
       callback(null, data)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash.foreach": "^4.0.0",
     "lodash.values": "^4.0.0",
     "node-zookeeper-client": "^0.2.1",
-    "request": "^2.49.0"
+    "request": "2.49.0 - 2.76.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Because the custom-error-generator library only supports formatting numbers and strings (as documented [here](https://github.com/jproulx/node-custom-error#formatting)).

Otherwise, the `%j` is never replaced.