### PR TITLE
Allow passing a writable to query object for streaming

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -228,5 +228,27 @@ Client.prototype.exec = function(query, callback) {
       callback(null, data)
     }
   }
+};
+
+/**
+ * Execute query and pipe it to writable
+ *
+ * @public
+ * @param {Query} query Query object
+ * @param {stream.Writable} writable a Writable instance to pipe the response through
+ */
+Client.prototype.pipe = function(query, writable) {
+  var err = query.validate()
+
+  if (err) {
+    return callback(err)
+  }
+
+  return request({
+    url:    this.url + '/druid/v2',
+    method: 'POST',
+    json:   true,
+    body:   query.toJSON()
+  }).pipe(writable)
 }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -257,6 +257,20 @@ Query.prototype.exec = function(callback) {
   this.client.exec(this, callback)
 }
 
+/**
+ * Execute streamed query
+ *
+ * @public
+ * @param {stream.Writable} writable Passed in to request.pipe for streaming response
+ */
+Query.prototype.pipe = function(writable) {
+  if (!this.client) {
+    throw new Error('Query is not attached. Use Druid#pipe(writable) instead!')
+  }
+
+  return this.client.pipe(this, writable)
+}
+
 
 
 


### PR DESCRIPTION
Allow passing in a [`stream.Writable`](https://nodejs.org/api/stream.html#stream_class_stream_writable) object for streaming the request response.

This allows efficient memory use in case of large druid response payloads.