### PR TITLE
Wrong field names for javascript aggregation

### DIFF
--- a/lib/fields/aggregations/javascript.js
+++ b/lib/fields/aggregations/javascript.js
@@ -9,17 +9,17 @@ var FieldError = require('../../errors').FieldError
  * @see http://druid.io/docs/0.6.120/Aggregations.html
  *
  * @param {string[]} fieldNames Names of fields which are passed to aggregate function
- * @param {string|Function} aggregateFn Aggregation function
- * @param {string|Function} combineFn Combines partials
- * @param {string|Function} resetFn Reset function
+ * @param {string|Function} fnAggregate Aggregation function
+ * @param {string|Function} fnCombine Combines partials
+ * @param {string|Function} fnReset Reset function
  */
-module.exports = function javascript(fieldNames, aggregateFn, combineFn, resetFn) {
-  if (!fieldNames || !fieldNames.length || !aggregateFn || !combineFn || !resetFn) {
+module.exports = function javascript(fieldNames, fnAggregate, fnCombine, fnReset) {
+  if (!fieldNames || !fieldNames.length || !fnAggregate || !fnCombine || !fnReset) {
     throw new FieldError('Some arguments ares missing (btw, all arguments are mandatory)')
   }
 
   this.fieldNames = fieldNames
-  this.aggregateFn = aggregateFn + ''
-  this.combineFn = combineFn + ''
-  this.resetFn = resetFn + ''
+  this.fnAggregate = fnAggregate + ''
+  this.fnCombine = fnCombine + ''
+  this.fnReset = fnReset + ''
 }


### PR DESCRIPTION
Hi,
Its awesome to write queries with your lib. Thank you for providing it! Unfortunately, I found a bug in the javascript aggregation. The field names of aggregateFn, combineFn and resetFn are wrong.

https://druid.apache.org/docs/latest/querying/aggregations#javascript-aggregator