### PR TITLE
update Apache Druid URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ druid-query
 
 [![NPM version](https://badge.fury.io/js/druid-query.svg)](http://badge.fury.io/js/druid-query) [![Build Status](https://travis-ci.org/7eggs/node-druid-query.svg)](https://travis-ci.org/7eggs/node-druid-query)
 
-Simple querying for Druid (http://druid.io) in Node.js. Inspired by [ruby-druid](https://github.com/liquidm/ruby-druid).
+Simple querying for [Apache Druid] (https://druid.apache.org) in Node.js. Inspired by [ruby-druid](https://github.com/liquidm/ruby-druid).
 
 Table of Contents:
 


### PR DESCRIPTION
cool query tool! I'll check it out. In the meantime, I'm updating the Apache Druid URL to druid.apache.org. thanks!